### PR TITLE
Variable table row height

### DIFF
--- a/src/pages/my-time-registration/parts/TimeRegistrationGrid.svelte
+++ b/src/pages/my-time-registration/parts/TimeRegistrationGrid.svelte
@@ -58,6 +58,10 @@
 </Table>
 
 <style>
+  :global(.bx--data-table tr) {
+    min-height: 3rem;
+    height: auto;
+  }
   :global(.bx--data-table--sticky-header) {
     max-height: calc(100vh - 342px) !important;
   }


### PR DESCRIPTION
Made the row height variable for the time registration table.
It is especially useful for tasks on the Pharma project because of the usual long description.

**Before:**
![image](https://github.com/yonder-makers/svelte-office-ui/assets/56274606/c5442f07-21e1-4954-bab8-c84ca2aaea89)

**After:**
![image](https://github.com/yonder-makers/svelte-office-ui/assets/56274606/3be597ce-34e2-4358-ad09-16848279d97c)