### PR TITLE
Search for task functionality

### DIFF
--- a/src/apis/tasks.api.ts
+++ b/src/apis/tasks.api.ts
@@ -1,8 +1,11 @@
-import { doGet } from './core/base-api';
+import {doGet} from './core/base-api';
 
-export async function getTasks() {
-  // not used for now, but helpful later after we enhance "explore tasks page"
-  const result = await doGet('/api/tasks');
+export async function getTasks(signal?: AbortSignal): Promise<TaskDto[]> {
+  const result = await doGet<TaskDto[]>(
+      '/api/tasks',
+      undefined,
+      signal
+  );
   return result;
 }
 

--- a/src/pages/my-time-registration/MyTimeRegistrationPage.svelte
+++ b/src/pages/my-time-registration/MyTimeRegistrationPage.svelte
@@ -30,6 +30,10 @@
 <EditLogModal />
 
 <style>
+  :global(#main-content) {
+    padding-bottom: 0;
+  }
+
   .footer-actions {
     margin-top: 12px;
     box-sizing: border-box;

--- a/src/pages/my-time-registration/modals/AddTaskModal.svelte
+++ b/src/pages/my-time-registration/modals/AddTaskModal.svelte
@@ -1,12 +1,8 @@
 <script lang="ts">
-  import {
-    Button,
-    Modal,
-    Tabs, Tab, TabContent
-  } from 'carbon-components-svelte';
-  import AddTaskModalById from './AddTaskModalById.svelte';
-
+  import {Button, Modal, Tab, TabContent, Tabs} from 'carbon-components-svelte';
   import AddTaskModalFavorites from './AddTaskModalFavorites.svelte';
+  import AddTaskModalById from './AddTaskModalById.svelte';
+  import AddTaskModalSearch from './AddTaskModalSearch.svelte';
 
   let open = false;
   
@@ -26,6 +22,7 @@
   <Tabs>
     <Tab label="Your favorite tasks" />
     <Tab label="Find by task ID" />
+    <Tab label="Find task"/>
     <svelte:fragment slot="content">
       <TabContent>
         <AddTaskModalFavorites on:onTasksAdded={() => open = false}  />
@@ -33,6 +30,16 @@
       <TabContent>
         <AddTaskModalById on:onTasksAdded={() => open = false} />
       </TabContent>
+      <TabContent>
+        <AddTaskModalSearch on:onTasksAdded={() => open = false}/>
+      </TabContent>
     </svelte:fragment>
 </Tabs>
 </Modal>
+
+<style>
+  :global(.bx--modal-content) {
+    padding-right: 0 !important;
+    margin-bottom: 0 !important;
+  }
+</style>

--- a/src/pages/my-time-registration/modals/AddTaskModalById.svelte
+++ b/src/pages/my-time-registration/modals/AddTaskModalById.svelte
@@ -8,10 +8,11 @@
     StructuredListCell,
     StructuredListRow,
   } from 'carbon-components-svelte';
-  import type { TaskDto } from '../../../apis/tasks.api';
-  import { getTaskById } from '../../../apis/tasks.api';
-  import { addNewTask } from '../store/actions';
-  import { createEventDispatcher } from 'svelte';
+  import type {TaskDto} from '../../../apis/tasks.api';
+  import {getTaskById} from '../../../apis/tasks.api';
+  import {addNewTask} from '../store/actions';
+  import {createEventDispatcher} from 'svelte';
+
   const dispatch = createEventDispatcher();
 
   let taskId = '';
@@ -63,13 +64,7 @@
       </StructuredListRow>
       <StructuredListRow>
         <StructuredListCell noWrap>Description</StructuredListCell>
-        <StructuredListCell>{selectedTask.description}</StructuredListCell>
-      </StructuredListRow>
-      <StructuredListRow>
-        <StructuredListCell noWrap>Description 2</StructuredListCell>
-        <StructuredListCell
-          >{selectedTask.custRefDescription}</StructuredListCell
-        >
+        <StructuredListCell>{selectedTask.custRefDescription || selectedTask.description}</StructuredListCell>
       </StructuredListRow>
     </StructuredListBody>
   </StructuredList>

--- a/src/pages/my-time-registration/modals/AddTaskModalFavorites.svelte
+++ b/src/pages/my-time-registration/modals/AddTaskModalFavorites.svelte
@@ -47,7 +47,7 @@
       disabled={$tasksState.byId[favorite.taskNumber] !== undefined}
       on:check={onToggle}
       bind:checked={selected[favorite.taskNumber]}
-      labelText={`${favorite.taskNumber} - ${favorite.projectName}, ${favorite.description}`}
+      labelText={`${favorite.taskNumber} - ${favorite.projectName ? favorite.projectName + ', ' : ''}${favorite.description}`}
     />
   {/each}
 

--- a/src/pages/my-time-registration/modals/AddTaskModalSearch.svelte
+++ b/src/pages/my-time-registration/modals/AddTaskModalSearch.svelte
@@ -35,8 +35,8 @@
   }
 </script>
 
+<!--the table can't be made stickyHeader because a lot of things break-->
 <DataTable
-        stickyHeader
         headers={[
                     { key: "add", value: "Add" },
                     { key: "taskId", value: "ID" },
@@ -69,7 +69,6 @@
         />
 
         <!--  after upgrading carbon components svelte version-->
-
 <!--        <ToolbarSearch-->
 <!--                persistent-->
 <!--                shouldFilterRows={(task, value) => {-->

--- a/src/pages/my-time-registration/modals/AddTaskModalSearch.svelte
+++ b/src/pages/my-time-registration/modals/AddTaskModalSearch.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+  import {Checkbox, DataTable, Search, Toolbar, ToolbarContent} from 'carbon-components-svelte';
+  import {addNewTask, assignableTasks, tasksState} from '../store';
+  import type {TaskDto} from "../../../apis/tasks.api";
+
+  let value = '';
+  let filtered = $assignableTasks;
+
+  const selected: Record<number, boolean> = {};
+
+  $: filtered = $assignableTasks
+          .map((task: TaskDto) => {
+            return {
+              ...task,
+              // DataTable requires a field "id" on the entity
+              id: task.taskId,
+              // both descriptions are consolidated in a single one
+              description: task.custRefDescription ? task.custRefDescription : task.description
+            }
+          })
+          .filter((task: TaskDto) => {
+            return value == ''
+                    || task.taskId.toString().includes(value)
+                    || task.project.toString().includes(value)
+                    || task.description.toString().includes(value)
+          })
+          .sort((a: TaskDto, b: TaskDto) => a.taskId > b.taskId);
+
+  function onCheck(task: TaskDto) {
+    try {
+      addNewTask(task);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+</script>
+
+<DataTable
+        stickyHeader
+        headers={[
+                    { key: "add", value: "Add" },
+                    { key: "taskId", value: "ID" },
+                    { key: "project", value: "Project" },
+                    { key: "description", value: "Description" },
+                 ]}
+        rows={filtered}
+>
+
+  <svelte:fragment slot="cell" let:row let:cell>
+    {#if cell.key === "add"}
+      <Checkbox
+              indeterminate={$tasksState.byId[row.taskId] !== undefined}
+              disabled={$tasksState.byId[row.taskId] !== undefined || selected[row.taskId]}
+              bind:checked={selected[row.taskId]}
+              on:check={(_event) => {onCheck(row)}}
+      />
+    {:else}
+      {cell.value}
+    {/if}
+  </svelte:fragment>
+
+    <Toolbar>
+      <ToolbarContent>
+        <Search
+                bind:value
+                size="lg"
+                searchClass="task__search"
+                placeholder="Search here for id, project or description."
+        />
+
+        <!--  after upgrading carbon components svelte version-->
+
+<!--        <ToolbarSearch-->
+<!--                persistent-->
+<!--                shouldFilterRows={(task, value) => {-->
+<!--            return value === ''-->
+<!--                      || task.taskId.toString().includes(value)-->
+<!--                      || task.project.toString().includes(value)-->
+<!--                      || task.description.toString().includes(value)-->
+<!--          }}-->
+<!--        />-->
+      </ToolbarContent>
+    </Toolbar>
+</DataTable>
+
+<style>
+  :global(.bx--tab-content) {
+    padding: 0 !important;
+  }
+</style>

--- a/src/pages/my-time-registration/store/actions.ts
+++ b/src/pages/my-time-registration/store/actions.ts
@@ -55,6 +55,7 @@ import {
   importEntriesSafeCopy,
   displayWeekend,
   favoritesTasks,
+  assignableTasks
 } from './state';
 
 export function changeDisplayWeekend(newValue: boolean) {
@@ -147,10 +148,12 @@ export function logEntriesLoaded(
   entries: LogEntry[],
   types: TypeOfWorkDto[],
   favs: FavoriteTaskDto[],
+  assignable: TaskDto[],
 ) {
   logEntries.set(entries);
   typesOfWork.set(types);
   favoritesTasks.set(favs);
+  assignableTasks.set(assignable);
 
   const tasks = uniqBy(
     entries.map(

--- a/src/pages/my-time-registration/store/actions.ts
+++ b/src/pages/my-time-registration/store/actions.ts
@@ -156,7 +156,7 @@ export function logEntriesLoaded(
     entries.map(
       (log) =>
       ({
-        description: log.custRefDescription,
+        description: log.custRefDescription || log.description,
         project: log.projectName,
         taskId: log.taskId,
       } as Task),

--- a/src/pages/my-time-registration/store/effects.ts
+++ b/src/pages/my-time-registration/store/effects.ts
@@ -34,6 +34,7 @@ import {
   LogEntry,
   selectedLogs,
 } from './state';
+import {getTasks} from "../../../apis/tasks.api";
 
 async function onDataNeedsRefresh(signal: AbortSignal, refreshDate: Date) {
   if (!refreshDate) {
@@ -43,13 +44,14 @@ async function onDataNeedsRefresh(signal: AbortSignal, refreshDate: Date) {
   const month = get(currentMonthState);
   logEntriesLoadingStarted();
 
-  const [tasksLog, typesOfWork, favoriteTasks] = await Promise.all([
+  const [tasksLog, typesOfWork, favoriteTasks, assignableTasks] = await Promise.all([
     fetchTasksLog(startOfMonth(month), endOfMonth(month), signal),
     fetchTypesOfWork(signal),
     fetchFavoriteTasks(signal),
+    getTasks(signal),
   ]);
 
-  logEntriesLoaded(tasksLog, typesOfWork, favoriteTasks);
+  logEntriesLoaded(tasksLog, typesOfWork, favoriteTasks, assignableTasks);
 }
 
 export async function startTogglImport(signal?: AbortSignal) {

--- a/src/pages/my-time-registration/store/state.ts
+++ b/src/pages/my-time-registration/store/state.ts
@@ -2,6 +2,7 @@ import { startOfMonth } from 'date-fns';
 import type { FavoriteTaskDto } from '../../../apis/favorite-tasks.api';
 import { writable } from 'svelte/store';
 import type { TypeOfWorkDto } from '../../../apis/types-of-work.api';
+import type {TaskDto} from "../../../apis/tasks.api";
 
 export interface LogEntry {
   uid: string;
@@ -64,3 +65,5 @@ export const importinfo = writable<ImportLogAttributes>({
 });
 
 export const favoritesTasks = writable<FavoriteTaskDto[]>([]);
+
+export const assignableTasks = writable<TaskDto[]>([]);


### PR DESCRIPTION
Fixed description for older tasks:

Before:
<img width="101" alt="chrome_xIWlyPG5dC" src="https://github.com/yonder-makers/svelte-office-ui/assets/56274606/02a8346d-9315-427d-944c-c3feb90ba38a">

After:
<img width="99" alt="chrome_IHCgxLcX13" src="https://github.com/yonder-makers/svelte-office-ui/assets/56274606/ec70680a-60fb-4c13-a886-632142f94f37">

New tab for searching for tasks:
![image](https://github.com/yonder-makers/svelte-office-ui/assets/56274606/e5ff932e-84e3-4e14-b914-0765eb54b94c)

1. Added in the same place as "Find by task ID", in the future it could be replaced altogether.
2. Search can be done by id, project or description
3. All of the tasks can be added by clicking on the checkbox, once added it will stay for the current session


- The table header can't be made static because it will break the column widths and it will add an extra scrollbar that can't be easily fixed
- It would be nice if in the future, the make favorite functionality will be managed from here, as of now it is a bit confusing to use